### PR TITLE
去除了:has()选择器以支持Firefox浏览器

### DIFF
--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -258,9 +258,15 @@ function checkAuth() {
 
 // 更新UI以反映认证状态
 function updateAuthUI(isAuthenticated) {
-    const createEventCard = document.querySelector('.card:has(#event-form)');
+    const cardList = document.querySelectorAll('.card');
+    let createEventCard = null;
+    cardList.forEach(card => {
+        if (card.querySelector('#event-form')) {
+            createEventCard = card;
+        }
+    });
+
     const loginPrompt = document.getElementById('login-prompt');
-    
     if (createEventCard) {
         if (isAuthenticated) {
             createEventCard.classList.remove('d-none');


### PR DESCRIPTION
将:has()选择器更换为DOM遍历，解决了Firefox浏览器下安全事件列表无法加载和安全事件无法添加的问题。